### PR TITLE
regions plugin: restore support for one drag selection for all channels

### DIFF
--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -299,7 +299,7 @@ export default class RegionsPlugin {
             );
 
             // set the region channel index based on the clicked area
-            if (this.wavesurfer.params.splitChannels) {
+            if (this.wavesurfer.params.splitChannels && this.wavesurfer.params.splitChannelsOptions.splitDragSelection) {
                 const y = (e.touches ? e.touches[0].clientY : e.clientY) - wrapperRect.top;
                 const channelCount = this.wavesurfer.backend.buffer != null ? this.wavesurfer.backend.buffer.numberOfChannels : 1;
                 const channelHeight = this.wrapper.clientHeight / channelCount;

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -174,6 +174,7 @@ import MediaElementWebAudio from './mediaelement-webaudio';
  * @property {boolean} relativeNormalization=false determines whether
  * normalization is done per channel or maintains proportionality between
  * channels. Only applied when normalize and splitChannels are both true.
+ * @property {boolean} splitDragSelection=false determines if drag selection in regions plugin works separately on each channel or only one selection for all channels
  * @since 4.3.0
  */
 
@@ -298,7 +299,8 @@ export default class WaveSurfer extends util.Observer {
             overlay: false,
             channelColors: {},
             filterChannels: [],
-            relativeNormalization: false
+            relativeNormalization: false,
+            splitDragSelection: false
         },
         vertical: false,
         waveColor: '#999',


### PR DESCRIPTION
### Short description of changes:
add `splitDragSelection` (default false) in `splitChannelsOptions` and check on it when splitting the drag selection
### Todos/Notes:
maybe update annotation example to include this

### Related Issues and other PRs:
#2529, #2380